### PR TITLE
Reorder Placeholder link in AppNavbar

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -77,14 +77,14 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/help_requests">
                     HelpRequests
                   </Nav.Link>
-                  <Nav.Link as={Link} to="/placeholder">
-                    Placeholder
-                  </Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdiningcommonsmenuitem">
                     UCSB Dining Commons Menu Item
                   </Nav.Link>
                   <Nav.Link as={Link} to="/MenuItemReview">
                     MenuItemReview
+                  </Nav.Link>
+                  <Nav.Link as={Link} to="/placeholder">
+                    Placeholder
                   </Nav.Link>
                 </>
               ) : (


### PR DESCRIPTION
In this PR, places Placeholder at the end of the Navbar

No issue linked


# Original
<img width="1720" height="191" alt="image" src="https://github.com/user-attachments/assets/cee57de4-11db-4948-ac01-f61665144c80" />

# New