### PR TITLE
Created two integration tests for HelpRequest

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/integration/HelpRequestIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/HelpRequestIT.java
@@ -1,0 +1,108 @@
+package edu.ucsb.cs156.example.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.HelpRequest;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class HelpRequestIT {
+  @Autowired public CurrentUserService currentUserService;
+
+  @Autowired public GrantedAuthoritiesService grantedAuthoritiesService;
+
+  @Autowired HelpRequestRepository helpRequestRepository;
+
+  @Autowired public MockMvc mockMvc;
+
+  @Autowired public ObjectMapper mapper;
+
+  @MockitoBean UserRepository userRepository;
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    // arrange
+
+    HelpRequest helpRequest =
+        HelpRequest.builder()
+            .id(0)
+            .requesterEmail("hao_ding@ucsb.edu")
+            .teamId("13")
+            .tableOrBreakoutRoom("12")
+            .requestTime(LocalDateTime.parse("2025-11-05T19:12:00"))
+            .explanation("I need help!!!")
+            .solved(false)
+            .build();
+
+    helpRequestRepository.save(helpRequest);
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/help_requests?id=1")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(helpRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_helpRequest() throws Exception {
+    // arrange
+
+    HelpRequest helpRequest1 =
+        HelpRequest.builder()
+            .id(1)
+            .requesterEmail("zhangchi@ucsb.edu")
+            .teamId("5")
+            .tableOrBreakoutRoom("6")
+            .requestTime(LocalDateTime.parse("2015-11-05T19:12:00"))
+            .explanation("I don't need help!!!")
+            .solved(true)
+            .build();
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/help_requests/post?requesterEmail=zhangchi@ucsb.edu&teamId=5&tableOrBreakoutRoom=6&requestTime=2015-11-05T19:12:00&explanation=I don't need help!!!&solved=true")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    String expectedJson = mapper.writeValueAsString(helpRequest1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Closes #108 

In this PR, we created two integrations for the get_by_id and post endpoints of the HelpRequest table. 